### PR TITLE
Fix for wrong parameter check in processPayment method.

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -17,7 +17,7 @@ if(Meteor.isServer){
     },
     processPayment : function(checkout){
       check(checkout, Match.ObjectIncluding({
-        card_id: String
+        cart_id: String
       }));
 
       //never trust the client, build the sale from the saved data


### PR DESCRIPTION
The code as is currently crashes when return from Stripe payment because the processPayment method checks for a property that is not there - "card_id".
