### PR TITLE
add link to Stripe checkout.js to main.html

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -1,3 +1,4 @@
 <head>
   <title>The Rocket Shop</title>
+  <script src="https://checkout.stripe.com/checkout.js" charset="utf-8"></script>
 </head>


### PR DESCRIPTION
The PR from Aug 7 removed the local copy of `stripe_checkout.js`.  https://github.com/robconery/meteor-shop/pull/5

The comment mentioned putting a link to `https://checkout.stripe.com/checkout.js` in `main.html`, but they didn't actually update `main.html`.
